### PR TITLE
Use lazy deadline check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>2.6.0</version>
+            <version>3.2.3</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/dev/vality/disputes/schedule/core/PendingDisputesService.java
+++ b/src/main/java/dev/vality/disputes/schedule/core/PendingDisputesService.java
@@ -50,8 +50,6 @@ public class PendingDisputesService {
             // validate
             disputesService.checkPendingStatus(dispute);
             // validate
-            pollingInfoService.checkDeadline(dispute);
-            // validate
             var invoicePayment = invoicingService.getInvoicePayment(dispute.getInvoiceId(), dispute.getPaymentId());
             // validate
             PaymentStatusValidator.checkStatus(invoicePayment);
@@ -61,7 +59,11 @@ public class PendingDisputesService {
                     case STATUS_SUCCESS -> disputeStatusResultHandler.handleCreateAdjustmentResult(
                             dispute, result, providerData, invoicePayment.getLastTransactionInfo());
                     case STATUS_FAIL -> disputeStatusResultHandler.handleFailedResult(dispute, result);
-                    case STATUS_PENDING -> disputeStatusResultHandler.handlePendingResult(dispute, providerData);
+                    case STATUS_PENDING -> {
+                        // validate
+                        pollingInfoService.checkDeadline(dispute);
+                        disputeStatusResultHandler.handlePendingResult(dispute, providerData);
+                    }
                     default -> throw new IllegalArgumentException(result.getSetField().getFieldName());
                 }
             };


### PR DESCRIPTION
Сейчас, при "пробуждении" диспута, когда хочется перепроверить его статус, приходится держать в уме настройки поллинга. Так как порой `disputes-api` по расписанию достает такой диспут, а он уже просрочен. Кажется логичным переводить диспут в `expired` только после проверки статуса. Лишний запрос ничем не грозит, но убирает необходимость следить за поллингом. Аналогичный подход у нас кажется реализован и на платежах.

Обновил `tika-core`, поскольку на нее ругался `dependabot`